### PR TITLE
chore: prepare next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/op
 
 ### :rocket: (Enhancement)
 
+### :bug: (Bug Fix)
+
+### :books: (Refine Doc)
+
+### :house: (Internal)
+
+## 1.26.0
+
+### :rocket: (Enhancement)
+
 * feat: include instrumentation scope info in console span and log record exporters [#4848](https://github.com/open-telemetry/opentelemetry-js/pull/4848) @blumamir
 * feat(semconv): update semantic conventions to 1.27 (from 1.7.0) [#4690](https://github.com/open-telemetry/opentelemetry-js/pull/4690) @dyladan
   * Exported names have changed to `ATTR_{name}` for attributes (e.g. `ATTR_HTTP_REQUEST_METHOD`), `{name}_VALUE_{value}` for enumeration values (e.g. `HTTP_REQUEST_METHOD_VALUE_POST`), and `METRIC_{name}` for metrics. Exported names from previous versions are deprecated.
@@ -23,8 +33,6 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/op
 
 * fix(sdk-node): avoid spurious diag errors for unknown OTEL_NODE_RESOURCE_DETECTORS values [#4879](https://github.com/open-telemetry/opentelemetry-js/pull/4879) @trentm
 * deps(opentelemetry-instrumentation): Bump `shimmer` types to 1.2.0 [#4865](https://github.com/open-telemetry/opentelemetry-js/pull/4865) @lforst
-
-### :books: (Refine Doc)
 
 ### :house: (Internal)
 

--- a/examples/esm-http-ts/package.json
+++ b/examples/esm-http-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esm-http-ts",
   "private": true,
-  "version": "0.52.1",
+  "version": "0.53.0",
   "description": "Example of HTTP integration with OpenTelemetry using ESM and TypeScript",
   "main": "build/index.js",
   "type": "module",
@@ -35,9 +35,9 @@
     "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
     "@opentelemetry/instrumentation": "0.52.1",
     "@opentelemetry/instrumentation-http": "0.52.1",
-    "@opentelemetry/resources": "1.25.1",
-    "@opentelemetry/sdk-trace-base": "1.25.1",
-    "@opentelemetry/sdk-trace-node": "1.25.1",
-    "@opentelemetry/semantic-conventions": "1.25.1"
+    "@opentelemetry/resources": "1.26.0",
+    "@opentelemetry/sdk-trace-base": "1.26.0",
+    "@opentelemetry/sdk-trace-node": "1.26.0",
+    "@opentelemetry/semantic-conventions": "1.26.0"
   }
 }

--- a/examples/http/package.json
+++ b/examples/http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "http-example",
   "private": true,
-  "version": "0.52.1",
+  "version": "0.53.0",
   "description": "Example of HTTP integration with OpenTelemetry",
   "main": "index.js",
   "scripts": {
@@ -30,14 +30,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-jaeger": "1.25.1",
-    "@opentelemetry/exporter-zipkin": "1.25.1",
+    "@opentelemetry/exporter-jaeger": "1.26.0",
+    "@opentelemetry/exporter-zipkin": "1.26.0",
     "@opentelemetry/instrumentation": "0.52.1",
     "@opentelemetry/instrumentation-http": "0.52.1",
-    "@opentelemetry/resources": "1.25.1",
-    "@opentelemetry/sdk-trace-base": "1.25.1",
-    "@opentelemetry/sdk-trace-node": "1.25.1",
-    "@opentelemetry/semantic-conventions": "1.25.1"
+    "@opentelemetry/resources": "1.26.0",
+    "@opentelemetry/sdk-trace-base": "1.26.0",
+    "@opentelemetry/sdk-trace-node": "1.26.0",
+    "@opentelemetry/semantic-conventions": "1.26.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/http",
   "devDependencies": {

--- a/examples/https/package.json
+++ b/examples/https/package.json
@@ -1,7 +1,7 @@
 {
   "name": "https-example",
   "private": true,
-  "version": "0.52.1",
+  "version": "0.53.0",
   "description": "Example of HTTPs integration with OpenTelemetry",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -34,14 +34,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/exporter-jaeger": "1.25.1",
-    "@opentelemetry/exporter-zipkin": "1.25.1",
+    "@opentelemetry/exporter-jaeger": "1.26.0",
+    "@opentelemetry/exporter-zipkin": "1.26.0",
     "@opentelemetry/instrumentation": "0.52.1",
     "@opentelemetry/instrumentation-http": "0.52.1",
-    "@opentelemetry/resources": "1.25.1",
-    "@opentelemetry/sdk-trace-base": "1.25.1",
-    "@opentelemetry/sdk-trace-node": "1.25.1",
-    "@opentelemetry/semantic-conventions": "1.25.1"
+    "@opentelemetry/resources": "1.26.0",
+    "@opentelemetry/sdk-trace-base": "1.26.0",
+    "@opentelemetry/sdk-trace-node": "1.26.0",
+    "@opentelemetry/semantic-conventions": "1.26.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/https",
   "devDependencies": {

--- a/examples/opentelemetry-web/package.json
+++ b/examples/opentelemetry-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-opentelemetry-example",
   "private": true,
-  "version": "0.52.1",
+  "version": "0.53.0",
   "description": "Example of using @opentelemetry/sdk-trace-web and @opentelemetry/sdk-metrics in browser",
   "main": "index.js",
   "scripts": {
@@ -45,20 +45,20 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/context-zone": "1.25.1",
-    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/context-zone": "1.26.0",
+    "@opentelemetry/core": "1.26.0",
     "@opentelemetry/exporter-metrics-otlp-http": "0.52.1",
     "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
     "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
-    "@opentelemetry/exporter-zipkin": "1.25.1",
+    "@opentelemetry/exporter-zipkin": "1.26.0",
     "@opentelemetry/instrumentation": "0.52.1",
     "@opentelemetry/instrumentation-fetch": "0.52.1",
     "@opentelemetry/instrumentation-xml-http-request": "0.52.1",
-    "@opentelemetry/propagator-b3": "1.25.1",
-    "@opentelemetry/sdk-metrics": "1.25.1",
-    "@opentelemetry/sdk-trace-base": "1.25.1",
-    "@opentelemetry/sdk-trace-web": "1.25.1",
-    "@opentelemetry/semantic-conventions": "1.25.1"
+    "@opentelemetry/propagator-b3": "1.26.0",
+    "@opentelemetry/sdk-metrics": "1.26.0",
+    "@opentelemetry/sdk-trace-base": "1.26.0",
+    "@opentelemetry/sdk-trace-web": "1.26.0",
+    "@opentelemetry/semantic-conventions": "1.26.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web"
 }

--- a/examples/otlp-exporter-node/package.json
+++ b/examples/otlp-exporter-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-otlp-exporter-node",
   "private": true,
-  "version": "0.52.1",
+  "version": "0.53.0",
   "description": "Example of using @opentelemetry/collector-exporter in Node.js",
   "main": "index.js",
   "scripts": {
@@ -30,17 +30,17 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/core": "1.26.0",
     "@opentelemetry/exporter-metrics-otlp-grpc": "0.52.1",
     "@opentelemetry/exporter-metrics-otlp-http": "0.52.1",
     "@opentelemetry/exporter-metrics-otlp-proto": "0.52.1",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
     "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
     "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
-    "@opentelemetry/resources": "1.25.1",
-    "@opentelemetry/sdk-metrics": "1.25.1",
-    "@opentelemetry/sdk-trace-base": "1.25.1",
-    "@opentelemetry/semantic-conventions": "1.25.1"
+    "@opentelemetry/resources": "1.26.0",
+    "@opentelemetry/sdk-metrics": "1.26.0",
+    "@opentelemetry/sdk-trace-base": "1.26.0",
+    "@opentelemetry/semantic-conventions": "1.26.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/otlp-exporter-node"
 }

--- a/experimental/backwards-compatibility/node14/package.json
+++ b/experimental/backwards-compatibility/node14/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node14",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "private": true,
   "description": "Backwards compatibility app for node 14 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@opentelemetry/sdk-node": "0.52.1",
-    "@opentelemetry/sdk-trace-base": "1.25.1"
+    "@opentelemetry/sdk-trace-base": "1.26.0"
   },
   "devDependencies": {
     "@types/node": "14.18.25",

--- a/experimental/backwards-compatibility/node16/package.json
+++ b/experimental/backwards-compatibility/node16/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node16",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "private": true,
   "description": "Backwards compatibility app for node 16 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@opentelemetry/sdk-node": "0.52.1",
-    "@opentelemetry/sdk-trace-base": "1.25.1"
+    "@opentelemetry/sdk-trace-base": "1.26.0"
   },
   "devDependencies": {
     "@types/node": "16.11.52",

--- a/experimental/examples/events/package.json
+++ b/experimental/examples/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "events-example",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "private": true,
   "scripts": {
     "start": "ts-node index.ts"

--- a/experimental/examples/logs/package.json
+++ b/experimental/examples/logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logs-example",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "private": true,
   "scripts": {
     "start": "ts-node index.ts",

--- a/experimental/examples/opencensus-shim/package.json
+++ b/experimental/examples/opencensus-shim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencensus-shim",
   "private": true,
-  "version": "0.52.1",
+  "version": "0.53.0",
   "description": "Example of using @opentelemetry/shim-opencensus in Node.js",
   "main": "index.js",
   "scripts": {
@@ -34,10 +34,10 @@
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/exporter-prometheus": "0.52.1",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
-    "@opentelemetry/resources": "1.25.1",
-    "@opentelemetry/sdk-metrics": "1.25.1",
-    "@opentelemetry/sdk-trace-node": "1.25.1",
-    "@opentelemetry/semantic-conventions": "1.25.1",
+    "@opentelemetry/resources": "1.26.0",
+    "@opentelemetry/sdk-metrics": "1.26.0",
+    "@opentelemetry/sdk-trace-node": "1.26.0",
+    "@opentelemetry/semantic-conventions": "1.26.0",
     "@opentelemetry/shim-opencensus": "0.52.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/examples/opencensus-shim"

--- a/experimental/examples/prometheus/package.json
+++ b/experimental/examples/prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prometheus-example",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "private": true,
   "description": "Example of using @opentelemetry/sdk-metrics and @opentelemetry/exporter-prometheus",
   "main": "index.js",
@@ -13,6 +13,6 @@
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/exporter-prometheus": "0.52.1",
-    "@opentelemetry/sdk-metrics": "1.25.1"
+    "@opentelemetry/sdk-metrics": "1.26.0"
   }
 }

--- a/integration-tests/api/package.json
+++ b/integration-tests/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/integration-tests-api",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propagation-validation-server",
-  "version": "1.26.1",
+  "version": "1.27.0",
   "description": "server for w3c tests",
   "main": "validation_server.js",
   "private": true,
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-async-hooks": "1.25.1",
-    "@opentelemetry/core": "1.25.1",
-    "@opentelemetry/sdk-trace-base": "1.25.1",
+    "@opentelemetry/context-async-hooks": "1.26.0",
+    "@opentelemetry/core": "1.26.0",
+    "@opentelemetry/sdk-trace-base": "1.26.0",
     "axios": "1.6.0",
     "body-parser": "1.19.0",
     "express": "4.19.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -221,17 +221,17 @@
       }
     },
     "examples/esm-http-ts": {
-      "version": "0.52.1",
+      "version": "0.53.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
         "@opentelemetry/instrumentation": "0.52.1",
         "@opentelemetry/instrumentation-http": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/sdk-trace-node": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/sdk-trace-node": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0"
       },
       "engines": {
         "node": ">=14"
@@ -239,18 +239,18 @@
     },
     "examples/http": {
       "name": "http-example",
-      "version": "0.52.1",
+      "version": "0.53.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-jaeger": "1.25.1",
-        "@opentelemetry/exporter-zipkin": "1.25.1",
+        "@opentelemetry/exporter-jaeger": "1.26.0",
+        "@opentelemetry/exporter-zipkin": "1.26.0",
         "@opentelemetry/instrumentation": "0.52.1",
         "@opentelemetry/instrumentation-http": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/sdk-trace-node": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/sdk-trace-node": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0"
       },
       "devDependencies": {
         "cross-env": "^6.0.0"
@@ -261,18 +261,18 @@
     },
     "examples/https": {
       "name": "https-example",
-      "version": "0.52.1",
+      "version": "0.53.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/exporter-jaeger": "1.25.1",
-        "@opentelemetry/exporter-zipkin": "1.25.1",
+        "@opentelemetry/exporter-jaeger": "1.26.0",
+        "@opentelemetry/exporter-zipkin": "1.26.0",
         "@opentelemetry/instrumentation": "0.52.1",
         "@opentelemetry/instrumentation-http": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/sdk-trace-node": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/sdk-trace-node": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0"
       },
       "devDependencies": {
         "cross-env": "^6.0.0"
@@ -283,24 +283,24 @@
     },
     "examples/opentelemetry-web": {
       "name": "web-opentelemetry-example",
-      "version": "0.52.1",
+      "version": "0.53.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-zone": "1.25.1",
-        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/context-zone": "1.26.0",
+        "@opentelemetry/core": "1.26.0",
         "@opentelemetry/exporter-metrics-otlp-http": "0.52.1",
         "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
         "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
-        "@opentelemetry/exporter-zipkin": "1.25.1",
+        "@opentelemetry/exporter-zipkin": "1.26.0",
         "@opentelemetry/instrumentation": "0.52.1",
         "@opentelemetry/instrumentation-fetch": "0.52.1",
         "@opentelemetry/instrumentation-xml-http-request": "0.52.1",
-        "@opentelemetry/propagator-b3": "1.25.1",
-        "@opentelemetry/sdk-metrics": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/sdk-trace-web": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/propagator-b3": "1.26.0",
+        "@opentelemetry/sdk-metrics": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/sdk-trace-web": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0"
       },
       "devDependencies": {
         "@babel/core": "^7.23.6",
@@ -332,21 +332,21 @@
     },
     "examples/otlp-exporter-node": {
       "name": "example-otlp-exporter-node",
-      "version": "0.52.1",
+      "version": "0.53.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/core": "1.26.0",
         "@opentelemetry/exporter-metrics-otlp-grpc": "0.52.1",
         "@opentelemetry/exporter-metrics-otlp-http": "0.52.1",
         "@opentelemetry/exporter-metrics-otlp-proto": "0.52.1",
         "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
         "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
         "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-metrics": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-metrics": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0"
       },
       "engines": {
         "node": ">=14"
@@ -354,11 +354,11 @@
     },
     "experimental/backwards-compatibility/node14": {
       "name": "backcompat-node14",
-      "version": "0.52.1",
+      "version": "0.53.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/sdk-node": "0.52.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1"
+        "@opentelemetry/sdk-trace-base": "1.26.0"
       },
       "devDependencies": {
         "@types/node": "14.18.25",
@@ -376,11 +376,11 @@
     },
     "experimental/backwards-compatibility/node16": {
       "name": "backcompat-node16",
-      "version": "0.52.1",
+      "version": "0.53.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/sdk-node": "0.52.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1"
+        "@opentelemetry/sdk-trace-base": "1.26.0"
       },
       "devDependencies": {
         "@types/node": "16.11.52",
@@ -398,7 +398,7 @@
     },
     "experimental/examples/events": {
       "name": "events-example",
-      "version": "0.52.1",
+      "version": "0.53.0",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/api-events": "0.52.1",
@@ -414,7 +414,7 @@
     },
     "experimental/examples/logs": {
       "name": "logs-example",
-      "version": "0.52.1",
+      "version": "0.53.0",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/api-logs": "0.52.1",
@@ -426,7 +426,7 @@
       }
     },
     "experimental/examples/opencensus-shim": {
-      "version": "0.52.1",
+      "version": "0.53.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opencensus/core": "0.1.0",
@@ -435,10 +435,10 @@
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/exporter-prometheus": "0.52.1",
         "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-metrics": "1.25.1",
-        "@opentelemetry/sdk-trace-node": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-metrics": "1.26.0",
+        "@opentelemetry/sdk-trace-node": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0",
         "@opentelemetry/shim-opencensus": "0.52.1"
       },
       "engines": {
@@ -447,12 +447,12 @@
     },
     "experimental/examples/prometheus": {
       "name": "prometheus-example",
-      "version": "0.52.1",
+      "version": "0.53.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/exporter-prometheus": "0.52.1",
-        "@opentelemetry/sdk-metrics": "1.25.1"
+        "@opentelemetry/sdk-metrics": "1.26.0"
       }
     },
     "experimental/packages/api-events": {
@@ -814,11 +814,53 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "experimental/packages/exporter-logs-otlp-grpc/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/exporter-logs-otlp-grpc/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/exporter-logs-otlp-grpc/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "experimental/packages/exporter-logs-otlp-grpc/node_modules/mocha": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
       "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
@@ -899,6 +941,47 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "experimental/packages/exporter-logs-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/exporter-logs-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/exporter-logs-otlp-http/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "experimental/packages/exporter-logs-otlp-http/node_modules/mocha": {
@@ -1077,11 +1160,69 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "experimental/packages/exporter-logs-otlp-proto/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/exporter-logs-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/exporter-logs-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+      "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/exporter-logs-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "experimental/packages/exporter-logs-otlp-proto/node_modules/mocha": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
       "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
@@ -1122,6 +1263,7 @@
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
       "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.20",
         "jest-worker": "^27.4.5",
@@ -1156,6 +1298,7 @@
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
       "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -1165,6 +1308,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
       "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -1240,6 +1384,63 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "experimental/packages/exporter-trace-otlp-grpc/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/exporter-trace-otlp-grpc/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/exporter-trace-otlp-grpc/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+      "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/exporter-trace-otlp-grpc/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "experimental/packages/exporter-trace-otlp-grpc/node_modules/mocha": {
@@ -1326,6 +1527,63 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "experimental/packages/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+      "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/exporter-trace-otlp-http/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "experimental/packages/exporter-trace-otlp-http/node_modules/mocha": {
@@ -1502,6 +1760,63 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "experimental/packages/exporter-trace-otlp-proto/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/exporter-trace-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+      "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/exporter-trace-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "experimental/packages/exporter-trace-otlp-proto/node_modules/mocha": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -1672,11 +1987,52 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "experimental/packages/opentelemetry-browser-detector/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-browser-detector/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-browser-detector/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "experimental/packages/opentelemetry-browser-detector/node_modules/mocha": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
       "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
@@ -1717,6 +2073,7 @@
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
       "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.20",
         "jest-worker": "^27.4.5",
@@ -1751,6 +2108,7 @@
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
       "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -1760,6 +2118,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
       "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -1836,6 +2195,63 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+      "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/node_modules/mocha": {
@@ -1922,6 +2338,63 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-metrics-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+      "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-metrics-otlp-http/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-http/node_modules/mocha": {
@@ -2087,6 +2560,63 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "experimental/packages/opentelemetry-exporter-metrics-otlp-proto/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-metrics-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-metrics-otlp-proto/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+      "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-metrics-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-proto/node_modules/mocha": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -2155,6 +2685,63 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-prometheus/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-prometheus/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-prometheus/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+      "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-prometheus/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "experimental/packages/opentelemetry-exporter-prometheus/node_modules/mocha": {
@@ -2293,6 +2880,124 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-fetch/node_modules/@opentelemetry/context-zone": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.25.1.tgz",
+      "integrity": "sha512-kHbMs95mKNJPpfd1LE1/IRxUw5D1fyTOM+0R1yDOOzffs9ZZsQqgQ1Q7q0bWZ/kVLWjL43fiALe+rPtQvRShdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-zone-peer-dep": "1.25.1",
+        "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-fetch/node_modules/@opentelemetry/context-zone-peer-dep": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.25.1.tgz",
+      "integrity": "sha512-UxSY9K90xOg2eI7qZStx0HV6DZT6tcRX+IiAWTvROi6h9Td2c2vlQhBZ9F1JH7kINmNCZN1f1//O9rSioPEMlg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "zone.js": "^0.10.2 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-fetch/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-fetch/node_modules/@opentelemetry/propagator-b3": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.25.1.tgz",
+      "integrity": "sha512-p6HFscpjrv7//kE+7L+3Vn00VEDUJB0n6ZrjkTYHrJ58QZ8B3ajSJhRbCcY6guQ3PDjTbxWklyvIN2ojVbIb1A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-fetch/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-fetch/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+      "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-fetch/node_modules/@opentelemetry/sdk-trace-web": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.25.1.tgz",
+      "integrity": "sha512-SS6JaSkHngcBCNdWGthzcvaKGRnDw2AeP57HyTEileLToJ7WLMeV+064iRlVyoT4+e77MRp2T2dDSrmaUyxoNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-fetch/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "experimental/packages/opentelemetry-instrumentation-fetch/node_modules/mocha": {
@@ -2465,11 +3170,138 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "experimental/packages/opentelemetry-instrumentation-grpc/node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.25.1.tgz",
+      "integrity": "sha512-UW/ge9zjvAEmRWVapOP0qyCvPulWU6cQxGxDbWEFfGOj1VBBZAuOqTo3X6yWmDTD3Xe15ysCZChHncr2xFMIfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-grpc/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-grpc/node_modules/@opentelemetry/propagator-b3": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.25.1.tgz",
+      "integrity": "sha512-p6HFscpjrv7//kE+7L+3Vn00VEDUJB0n6ZrjkTYHrJ58QZ8B3ajSJhRbCcY6guQ3PDjTbxWklyvIN2ojVbIb1A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-grpc/node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.25.1.tgz",
+      "integrity": "sha512-nBprRf0+jlgxks78G/xq72PipVK+4or9Ypntw0gVZYNTCSK8rg5SeaGV19tV920CMqBD/9UIOiFr23Li/Q8tiA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-grpc/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-grpc/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+      "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-grpc/node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.25.1.tgz",
+      "integrity": "sha512-nMcjFIKxnFqoez4gUmihdBrbpsEnAX/Xj16sGvZm+guceYE0NE00vLhpDVK6f3q8Q4VFI5xG8JjlXKMB/SkTTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/propagator-b3": "1.25.1",
+        "@opentelemetry/propagator-jaeger": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-grpc/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "experimental/packages/opentelemetry-instrumentation-grpc/node_modules/mocha": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
       "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
@@ -2545,6 +3377,149 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-http/node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.25.1.tgz",
+      "integrity": "sha512-UW/ge9zjvAEmRWVapOP0qyCvPulWU6cQxGxDbWEFfGOj1VBBZAuOqTo3X6yWmDTD3Xe15ysCZChHncr2xFMIfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-http/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-http/node_modules/@opentelemetry/propagator-b3": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.25.1.tgz",
+      "integrity": "sha512-p6HFscpjrv7//kE+7L+3Vn00VEDUJB0n6ZrjkTYHrJ58QZ8B3ajSJhRbCcY6guQ3PDjTbxWklyvIN2ojVbIb1A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-http/node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.25.1.tgz",
+      "integrity": "sha512-nBprRf0+jlgxks78G/xq72PipVK+4or9Ypntw0gVZYNTCSK8rg5SeaGV19tV920CMqBD/9UIOiFr23Li/Q8tiA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-http/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-http/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+      "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-http/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+      "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-http/node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.25.1.tgz",
+      "integrity": "sha512-nMcjFIKxnFqoez4gUmihdBrbpsEnAX/Xj16sGvZm+guceYE0NE00vLhpDVK6f3q8Q4VFI5xG8JjlXKMB/SkTTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/propagator-b3": "1.25.1",
+        "@opentelemetry/propagator-jaeger": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "experimental/packages/opentelemetry-instrumentation-http/node_modules/mocha": {
@@ -2633,6 +3608,124 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-xml-http-request/node_modules/@opentelemetry/context-zone": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.25.1.tgz",
+      "integrity": "sha512-kHbMs95mKNJPpfd1LE1/IRxUw5D1fyTOM+0R1yDOOzffs9ZZsQqgQ1Q7q0bWZ/kVLWjL43fiALe+rPtQvRShdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-zone-peer-dep": "1.25.1",
+        "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-xml-http-request/node_modules/@opentelemetry/context-zone-peer-dep": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.25.1.tgz",
+      "integrity": "sha512-UxSY9K90xOg2eI7qZStx0HV6DZT6tcRX+IiAWTvROi6h9Td2c2vlQhBZ9F1JH7kINmNCZN1f1//O9rSioPEMlg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "zone.js": "^0.10.2 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-xml-http-request/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-xml-http-request/node_modules/@opentelemetry/propagator-b3": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.25.1.tgz",
+      "integrity": "sha512-p6HFscpjrv7//kE+7L+3Vn00VEDUJB0n6ZrjkTYHrJ58QZ8B3ajSJhRbCcY6guQ3PDjTbxWklyvIN2ojVbIb1A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-xml-http-request/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-xml-http-request/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+      "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-xml-http-request/node_modules/@opentelemetry/sdk-trace-web": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.25.1.tgz",
+      "integrity": "sha512-SS6JaSkHngcBCNdWGthzcvaKGRnDw2AeP57HyTEileLToJ7WLMeV+064iRlVyoT4+e77MRp2T2dDSrmaUyxoNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation-xml-http-request/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "experimental/packages/opentelemetry-instrumentation-xml-http-request/node_modules/mocha": {
@@ -2763,6 +3856,67 @@
         "webpack-cli": {
           "optional": true
         }
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+      "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "experimental/packages/opentelemetry-instrumentation/node_modules/mocha": {
@@ -2939,6 +4093,179 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
+    "experimental/packages/opentelemetry-sdk-node/node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.25.1.tgz",
+      "integrity": "sha512-UW/ge9zjvAEmRWVapOP0qyCvPulWU6cQxGxDbWEFfGOj1VBBZAuOqTo3X6yWmDTD3Xe15ysCZChHncr2xFMIfQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-sdk-node/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-sdk-node/node_modules/@opentelemetry/exporter-jaeger": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.25.1.tgz",
+      "integrity": "sha512-6/HwzrwUx0fpkFXrouF0IJp+hpN8xkx8RqEk+BZfeoMAHydpyigyYsKyAtAZRwfJe45WWJbJUqoK8aBjiC9iLQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
+        "jaeger-client": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "experimental/packages/opentelemetry-sdk-node/node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.25.1.tgz",
+      "integrity": "sha512-RmOwSvkimg7ETwJbUOPTMhJm9A9bG1U8s7Zo3ajDh4zM7eYcycQ0dM7FbLD6NXWbI2yj7UY4q8BKinKYBQksyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "experimental/packages/opentelemetry-sdk-node/node_modules/@opentelemetry/propagator-b3": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.25.1.tgz",
+      "integrity": "sha512-p6HFscpjrv7//kE+7L+3Vn00VEDUJB0n6ZrjkTYHrJ58QZ8B3ajSJhRbCcY6guQ3PDjTbxWklyvIN2ojVbIb1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-sdk-node/node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.25.1.tgz",
+      "integrity": "sha512-nBprRf0+jlgxks78G/xq72PipVK+4or9Ypntw0gVZYNTCSK8rg5SeaGV19tV920CMqBD/9UIOiFr23Li/Q8tiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-sdk-node/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-sdk-node/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+      "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-sdk-node/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+      "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-sdk-node/node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.25.1.tgz",
+      "integrity": "sha512-nMcjFIKxnFqoez4gUmihdBrbpsEnAX/Xj16sGvZm+guceYE0NE00vLhpDVK6f3q8Q4VFI5xG8JjlXKMB/SkTTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/propagator-b3": "1.25.1",
+        "@opentelemetry/propagator-jaeger": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/opentelemetry-sdk-node/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "experimental/packages/opentelemetry-sdk-node/node_modules/mocha": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -3018,6 +4345,30 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "experimental/packages/otlp-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/otlp-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "experimental/packages/otlp-exporter-base/node_modules/mocha": {
@@ -3183,6 +4534,65 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "experimental/packages/otlp-grpc-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/otlp-grpc-exporter-base/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/otlp-grpc-exporter-base/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+      "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/otlp-grpc-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "experimental/packages/otlp-grpc-exporter-base/node_modules/mocha": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -3262,6 +4672,80 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "experimental/packages/otlp-transformer/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/otlp-transformer/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+      "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "experimental/packages/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+      "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/otlp-transformer/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "experimental/packages/otlp-transformer/node_modules/mocha": {
@@ -3426,11 +4910,51 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
+    "experimental/packages/propagator-aws-xray-lambda/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/propagator-aws-xray-lambda/node_modules/@opentelemetry/propagator-aws-xray": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.25.1.tgz",
+      "integrity": "sha512-soZQdO9EAROMwa9bL2C0VLadbrfRjSA9t7g6X8sL0X1B8V59pzOayYMyTW9qTECn9uuJV98A7qOnJm6KH6yk8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/propagator-aws-xray-lambda/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "experimental/packages/propagator-aws-xray-lambda/node_modules/mocha": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
       "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
@@ -3723,7 +5247,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
       "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
-      "dev": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3738,6 +5261,46 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "experimental/packages/sdk-logs/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/sdk-logs/node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "experimental/packages/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "experimental/packages/sdk-logs/node_modules/@opentelemetry/resources_1.9.0": {
@@ -3770,6 +5333,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "experimental/packages/sdk-logs/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "experimental/packages/sdk-logs/node_modules/@opentelemetry/semantic-conventions": {
@@ -3946,6 +5518,94 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "experimental/packages/shim-opencensus/node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.25.1.tgz",
+      "integrity": "sha512-UW/ge9zjvAEmRWVapOP0qyCvPulWU6cQxGxDbWEFfGOj1VBBZAuOqTo3X6yWmDTD3Xe15ysCZChHncr2xFMIfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/shim-opencensus/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/shim-opencensus/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/shim-opencensus/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+      "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "experimental/packages/shim-opencensus/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+      "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "experimental/packages/shim-opencensus/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "experimental/packages/shim-opencensus/node_modules/mocha": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -3988,7 +5648,7 @@
     },
     "integration-tests/api": {
       "name": "@opentelemetry/integration-tests-api",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
@@ -4046,13 +5706,13 @@
       }
     },
     "integration-tests/propagation-validation-server": {
-      "version": "1.26.1",
+      "version": "1.27.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/context-async-hooks": "1.25.1",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/context-async-hooks": "1.26.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
         "axios": "1.6.0",
         "body-parser": "1.19.0",
         "express": "4.19.2"
@@ -5953,6 +7613,7 @@
       "integrity": "sha512-WPO0dAc3eUr1gsaB0s9MdMrlqFVg8O8peMulSt7j2akPycI9CSHao0JD4qiM89+2xnexgEJ0iZeCHl8QchIQNQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "bin": {
         "buf": "bin/buf",
         "protoc-gen-buf-breaking": "bin/protoc-gen-buf-breaking",
@@ -5978,6 +7639,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -5994,6 +7656,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -6010,6 +7673,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -6026,6 +7690,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -6042,6 +7707,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -6058,6 +7724,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -8757,6 +10424,7 @@
       "resolved": "https://registry.npmjs.org/@protobuf-ts/grpc-transport/-/grpc-transport-2.9.4.tgz",
       "integrity": "sha512-CgjTR3utmkMkkThpfgtOz9tNR9ZARbNoQYL7TCKqFU2sgAX0LgzAkwOx+sfgtUsZn9J08+yvn307nNJdYocLRA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@protobuf-ts/runtime": "^2.9.4",
         "@protobuf-ts/runtime-rpc": "^2.9.4"
@@ -8769,13 +10437,15 @@
       "version": "2.9.4",
       "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.4.tgz",
       "integrity": "sha512-vHRFWtJJB/SiogWDF0ypoKfRIZ41Kq+G9cEFj6Qm1eQaAhJ1LDFvgZ7Ja4tb3iLOQhz0PaoPnnOijF1qmEqTxg==",
-      "dev": true
+      "dev": true,
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@protobuf-ts/runtime-rpc": {
       "version": "2.9.4",
       "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.9.4.tgz",
       "integrity": "sha512-y9L9JgnZxXFqH5vD4d7j9duWvIJ7AShyBRoNKJGhu9Q27qIbchfzli66H9RvrQNIFk5ER7z1Twe059WZGqERcA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@protobuf-ts/runtime": "^2.9.4"
       }
@@ -31333,7 +33003,7 @@
     },
     "packages/opentelemetry-context-async-hooks": {
       "name": "@opentelemetry/context-async-hooks",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
@@ -31395,10 +33065,10 @@
     },
     "packages/opentelemetry-context-zone": {
       "name": "@opentelemetry/context-zone",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-zone-peer-dep": "1.25.1",
+        "@opentelemetry/context-zone-peer-dep": "1.26.0",
         "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
       },
       "devDependencies": {
@@ -31412,7 +33082,7 @@
     },
     "packages/opentelemetry-context-zone-peer-dep": {
       "name": "@opentelemetry/context-zone-peer-dep",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.9",
@@ -31583,10 +33253,10 @@
     },
     "packages/opentelemetry-core": {
       "name": "@opentelemetry/core",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/semantic-conventions": "1.26.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
@@ -31750,17 +33420,17 @@
     },
     "packages/opentelemetry-exporter-jaeger": {
       "name": "@opentelemetry/exporter-jaeger",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0",
         "jaeger-client": "^3.15.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/resources": "1.26.0",
         "@types/mocha": "10.0.7",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -31822,13 +33492,13 @@
     },
     "packages/opentelemetry-exporter-zipkin": {
       "name": "@opentelemetry/exporter-zipkin",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.9",
@@ -31998,10 +33668,10 @@
     },
     "packages/opentelemetry-propagator-b3": {
       "name": "@opentelemetry/propagator-b3",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1"
+        "@opentelemetry/core": "1.26.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
@@ -32064,10 +33734,10 @@
     },
     "packages/opentelemetry-propagator-jaeger": {
       "name": "@opentelemetry/propagator-jaeger",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1"
+        "@opentelemetry/core": "1.26.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
@@ -32231,11 +33901,11 @@
     },
     "packages/opentelemetry-resources": {
       "name": "@opentelemetry/resources",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
@@ -32452,12 +34122,12 @@
     },
     "packages/opentelemetry-sdk-trace-base": {
       "name": "@opentelemetry/sdk-trace-base",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
@@ -32622,20 +34292,20 @@
     },
     "packages/opentelemetry-sdk-trace-node": {
       "name": "@opentelemetry/sdk-trace-node",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.25.1",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/propagator-b3": "1.25.1",
-        "@opentelemetry/propagator-jaeger": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/context-async-hooks": "1.26.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/propagator-b3": "1.26.0",
+        "@opentelemetry/propagator-jaeger": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
         "semver": "^7.5.2"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0",
         "@types/mocha": "10.0.7",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.8",
@@ -32697,20 +34367,20 @@
     },
     "packages/opentelemetry-sdk-trace-web": {
       "name": "@opentelemetry/sdk-trace-web",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.9",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/context-zone": "1.25.1",
-        "@opentelemetry/propagator-b3": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/context-zone": "1.26.0",
+        "@opentelemetry/propagator-b3": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
         "@types/jquery": "3.5.30",
         "@types/mocha": "10.0.7",
         "@types/node": "18.6.5",
@@ -32904,18 +34574,18 @@
     },
     "packages/opentelemetry-shim-opentracing": {
       "name": "@opentelemetry/shim-opentracing",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0",
         "opentracing": "^0.14.4"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/propagator-b3": "1.25.1",
-        "@opentelemetry/propagator-jaeger": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/propagator-b3": "1.26.0",
+        "@opentelemetry/propagator-jaeger": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
         "@types/mocha": "10.0.7",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -32974,10 +34644,10 @@
     },
     "packages/propagator-aws-xray": {
       "name": "@opentelemetry/propagator-aws-xray",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1"
+        "@opentelemetry/core": "1.26.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
@@ -33139,11 +34809,11 @@
     },
     "packages/sdk-metrics": {
       "name": "@opentelemetry/sdk-metrics",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
         "lodash.merge": "^4.6.2"
       },
       "devDependencies": {
@@ -33312,7 +34982,7 @@
     },
     "packages/semantic-conventions": {
       "name": "@opentelemetry/semantic-conventions",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@size-limit/file": "^11.0.1",
@@ -33378,7 +35048,7 @@
     },
     "packages/template": {
       "name": "@opentelemetry/template",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "18.6.5",
@@ -33392,19 +35062,19 @@
     },
     "selenium-tests": {
       "name": "@opentelemetry/selenium-tests",
-      "version": "1.26.1",
+      "version": "1.27.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-zone-peer-dep": "1.25.1",
-        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/context-zone-peer-dep": "1.26.0",
+        "@opentelemetry/core": "1.26.0",
         "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
-        "@opentelemetry/exporter-zipkin": "1.25.1",
+        "@opentelemetry/exporter-zipkin": "1.26.0",
         "@opentelemetry/instrumentation": "0.52.1",
         "@opentelemetry/instrumentation-fetch": "0.52.1",
         "@opentelemetry/instrumentation-xml-http-request": "0.52.1",
-        "@opentelemetry/sdk-metrics": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/sdk-trace-web": "1.25.1",
+        "@opentelemetry/sdk-metrics": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/sdk-trace-web": "1.26.0",
         "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
       },
       "devDependencies": {
@@ -37217,7 +38887,7 @@
     "@opentelemetry/context-zone": {
       "version": "file:packages/opentelemetry-context-zone",
       "requires": {
-        "@opentelemetry/context-zone-peer-dep": "1.25.1",
+        "@opentelemetry/context-zone-peer-dep": "1.26.0",
         "cross-var": "1.1.0",
         "lerna": "6.6.2",
         "typescript": "4.4.4",
@@ -37347,7 +39017,7 @@
       "version": "file:packages/opentelemetry-core",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.26.0",
         "@types/mocha": "10.0.7",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -37461,10 +39131,10 @@
       "version": "file:packages/opentelemetry-exporter-jaeger",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0",
         "@types/mocha": "10.0.7",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -37536,6 +39206,29 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -37604,6 +39297,29 @@
         "webpack-merge": "5.10.0"
       },
       "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -37727,6 +39443,38 @@
         "webpack-merge": "5.10.0"
       },
       "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+          "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -37840,6 +39588,38 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-metrics": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+          "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "lodash.merge": "^4.6.2"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -37907,6 +39687,38 @@
         "webpack-merge": "5.10.0"
       },
       "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-metrics": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+          "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "lodash.merge": "^4.6.2"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -38017,6 +39829,38 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-metrics": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+          "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "lodash.merge": "^4.6.2"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -38068,6 +39912,38 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-metrics": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+          "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "lodash.merge": "^4.6.2"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -38124,6 +40000,38 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+          "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -38191,6 +40099,38 @@
         "webpack-merge": "5.10.0"
       },
       "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+          "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -38312,6 +40252,38 @@
         "webpack-merge": "5.10.0"
       },
       "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+          "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -38405,10 +40377,10 @@
         "@babel/core": "7.24.9",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0",
         "@types/mocha": "10.0.7",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -38562,6 +40534,42 @@
         "webpack-merge": "5.10.0"
       },
       "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-metrics": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+          "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "lodash.merge": "^4.6.2"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+          "dev": true
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -38687,6 +40695,74 @@
         "webpack-merge": "5.10.0"
       },
       "dependencies": {
+        "@opentelemetry/context-zone": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.25.1.tgz",
+          "integrity": "sha512-kHbMs95mKNJPpfd1LE1/IRxUw5D1fyTOM+0R1yDOOzffs9ZZsQqgQ1Q7q0bWZ/kVLWjL43fiALe+rPtQvRShdg==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/context-zone-peer-dep": "1.25.1",
+            "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
+          }
+        },
+        "@opentelemetry/context-zone-peer-dep": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.25.1.tgz",
+          "integrity": "sha512-UxSY9K90xOg2eI7qZStx0HV6DZT6tcRX+IiAWTvROi6h9Td2c2vlQhBZ9F1JH7kINmNCZN1f1//O9rSioPEMlg==",
+          "dev": true,
+          "requires": {}
+        },
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/propagator-b3": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.25.1.tgz",
+          "integrity": "sha512-p6HFscpjrv7//kE+7L+3Vn00VEDUJB0n6ZrjkTYHrJ58QZ8B3ajSJhRbCcY6guQ3PDjTbxWklyvIN2ojVbIb1A==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+          "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-trace-web": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.25.1.tgz",
+          "integrity": "sha512-SS6JaSkHngcBCNdWGthzcvaKGRnDw2AeP57HyTEileLToJ7WLMeV+064iRlVyoT4+e77MRp2T2dDSrmaUyxoNg==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/sdk-trace-base": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -38804,6 +40880,80 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/context-async-hooks": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.25.1.tgz",
+          "integrity": "sha512-UW/ge9zjvAEmRWVapOP0qyCvPulWU6cQxGxDbWEFfGOj1VBBZAuOqTo3X6yWmDTD3Xe15ysCZChHncr2xFMIfQ==",
+          "dev": true,
+          "requires": {}
+        },
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/propagator-b3": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.25.1.tgz",
+          "integrity": "sha512-p6HFscpjrv7//kE+7L+3Vn00VEDUJB0n6ZrjkTYHrJ58QZ8B3ajSJhRbCcY6guQ3PDjTbxWklyvIN2ojVbIb1A==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1"
+          }
+        },
+        "@opentelemetry/propagator-jaeger": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.25.1.tgz",
+          "integrity": "sha512-nBprRf0+jlgxks78G/xq72PipVK+4or9Ypntw0gVZYNTCSK8rg5SeaGV19tV920CMqBD/9UIOiFr23Li/Q8tiA==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+          "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-trace-node": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.25.1.tgz",
+          "integrity": "sha512-nMcjFIKxnFqoez4gUmihdBrbpsEnAX/Xj16sGvZm+guceYE0NE00vLhpDVK6f3q8Q4VFI5xG8JjlXKMB/SkTTQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/context-async-hooks": "1.25.1",
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/propagator-b3": "1.25.1",
+            "@opentelemetry/propagator-jaeger": "1.25.1",
+            "@opentelemetry/sdk-trace-base": "1.25.1",
+            "semver": "^7.5.2"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -38867,6 +41017,90 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/context-async-hooks": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.25.1.tgz",
+          "integrity": "sha512-UW/ge9zjvAEmRWVapOP0qyCvPulWU6cQxGxDbWEFfGOj1VBBZAuOqTo3X6yWmDTD3Xe15ysCZChHncr2xFMIfQ==",
+          "dev": true,
+          "requires": {}
+        },
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/propagator-b3": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.25.1.tgz",
+          "integrity": "sha512-p6HFscpjrv7//kE+7L+3Vn00VEDUJB0n6ZrjkTYHrJ58QZ8B3ajSJhRbCcY6guQ3PDjTbxWklyvIN2ojVbIb1A==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1"
+          }
+        },
+        "@opentelemetry/propagator-jaeger": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.25.1.tgz",
+          "integrity": "sha512-nBprRf0+jlgxks78G/xq72PipVK+4or9Ypntw0gVZYNTCSK8rg5SeaGV19tV920CMqBD/9UIOiFr23Li/Q8tiA==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-metrics": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+          "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "lodash.merge": "^4.6.2"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+          "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-trace-node": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.25.1.tgz",
+          "integrity": "sha512-nMcjFIKxnFqoez4gUmihdBrbpsEnAX/Xj16sGvZm+guceYE0NE00vLhpDVK6f3q8Q4VFI5xG8JjlXKMB/SkTTQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/context-async-hooks": "1.25.1",
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/propagator-b3": "1.25.1",
+            "@opentelemetry/propagator-jaeger": "1.25.1",
+            "@opentelemetry/sdk-trace-base": "1.25.1",
+            "semver": "^7.5.2"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -38936,6 +41170,74 @@
         "webpack-merge": "5.10.0"
       },
       "dependencies": {
+        "@opentelemetry/context-zone": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.25.1.tgz",
+          "integrity": "sha512-kHbMs95mKNJPpfd1LE1/IRxUw5D1fyTOM+0R1yDOOzffs9ZZsQqgQ1Q7q0bWZ/kVLWjL43fiALe+rPtQvRShdg==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/context-zone-peer-dep": "1.25.1",
+            "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
+          }
+        },
+        "@opentelemetry/context-zone-peer-dep": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.25.1.tgz",
+          "integrity": "sha512-UxSY9K90xOg2eI7qZStx0HV6DZT6tcRX+IiAWTvROi6h9Td2c2vlQhBZ9F1JH7kINmNCZN1f1//O9rSioPEMlg==",
+          "dev": true,
+          "requires": {}
+        },
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/propagator-b3": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.25.1.tgz",
+          "integrity": "sha512-p6HFscpjrv7//kE+7L+3Vn00VEDUJB0n6ZrjkTYHrJ58QZ8B3ajSJhRbCcY6guQ3PDjTbxWklyvIN2ojVbIb1A==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+          "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-trace-web": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.25.1.tgz",
+          "integrity": "sha512-SS6JaSkHngcBCNdWGthzcvaKGRnDw2AeP57HyTEileLToJ7WLMeV+064iRlVyoT4+e77MRp2T2dDSrmaUyxoNg==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/sdk-trace-base": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -39098,6 +41400,28 @@
         "webpack-merge": "5.10.0"
       },
       "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -39216,6 +41540,19 @@
         "webpack-merge": "5.10.0"
       },
       "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -39326,6 +41663,40 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+          "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -39388,6 +41759,48 @@
         "webpack": "5.89.0"
       },
       "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-metrics": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+          "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "lodash.merge": "^4.6.2"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+          "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -39479,7 +41892,7 @@
       "version": "file:packages/propagator-aws-xray",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/core": "1.26.0",
         "@types/mocha": "10.0.7",
         "@types/node": "18.6.5",
         "@types/webpack-env": "1.16.3",
@@ -39609,6 +42022,27 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/propagator-aws-xray": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.25.1.tgz",
+          "integrity": "sha512-soZQdO9EAROMwa9bL2C0VLadbrfRjSA9t7g6X8sL0X1B8V59pzOayYMyTW9qTECn9uuJV98A7qOnJm6KH6yk8w==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -39644,7 +42078,7 @@
       "version": "file:packages/opentelemetry-propagator-b3",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/core": "1.26.0",
         "@types/mocha": "10.0.7",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -39691,7 +42125,7 @@
       "version": "file:packages/opentelemetry-propagator-jaeger",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/core": "1.26.0",
         "@types/mocha": "10.0.7",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -39805,9 +42239,9 @@
       "version": "file:packages/opentelemetry-resources",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/core": "1.26.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.26.0",
         "@types/mocha": "10.0.7",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -40136,8 +42570,7 @@
         "@opentelemetry/api": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
-          "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
-          "dev": true
+          "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA=="
         },
         "@opentelemetry/api-logs": {
           "version": "0.52.0",
@@ -40146,6 +42579,37 @@
           "dev": true,
           "requires": {
             "@opentelemetry/api": "^1.0.0"
+          }
+        },
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          },
+          "dependencies": {
+            "@opentelemetry/semantic-conventions": {
+              "version": "1.25.1",
+              "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+              "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+            }
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          },
+          "dependencies": {
+            "@opentelemetry/semantic-conventions": {
+              "version": "1.25.1",
+              "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+              "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+            }
           }
         },
         "@opentelemetry/resources_1.9.0": {
@@ -40268,8 +42732,8 @@
         "@babel/core": "7.24.9",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": ">=1.3.0 <1.10.0",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
         "@types/lodash.merge": "4.6.9",
         "@types/mocha": "10.0.7",
         "@types/node": "18.6.5",
@@ -40416,6 +42880,106 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/context-async-hooks": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.25.1.tgz",
+          "integrity": "sha512-UW/ge9zjvAEmRWVapOP0qyCvPulWU6cQxGxDbWEFfGOj1VBBZAuOqTo3X6yWmDTD3Xe15ysCZChHncr2xFMIfQ==",
+          "requires": {}
+        },
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/exporter-jaeger": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.25.1.tgz",
+          "integrity": "sha512-6/HwzrwUx0fpkFXrouF0IJp+hpN8xkx8RqEk+BZfeoMAHydpyigyYsKyAtAZRwfJe45WWJbJUqoK8aBjiC9iLQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/sdk-trace-base": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1",
+            "jaeger-client": "^3.15.0"
+          }
+        },
+        "@opentelemetry/exporter-zipkin": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.25.1.tgz",
+          "integrity": "sha512-RmOwSvkimg7ETwJbUOPTMhJm9A9bG1U8s7Zo3ajDh4zM7eYcycQ0dM7FbLD6NXWbI2yj7UY4q8BKinKYBQksyw==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/sdk-trace-base": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/propagator-b3": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.25.1.tgz",
+          "integrity": "sha512-p6HFscpjrv7//kE+7L+3Vn00VEDUJB0n6ZrjkTYHrJ58QZ8B3ajSJhRbCcY6guQ3PDjTbxWklyvIN2ojVbIb1A==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1"
+          }
+        },
+        "@opentelemetry/propagator-jaeger": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.25.1.tgz",
+          "integrity": "sha512-nBprRf0+jlgxks78G/xq72PipVK+4or9Ypntw0gVZYNTCSK8rg5SeaGV19tV920CMqBD/9UIOiFr23Li/Q8tiA==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-metrics": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+          "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "lodash.merge": "^4.6.2"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+          "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-trace-node": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.25.1.tgz",
+          "integrity": "sha512-nMcjFIKxnFqoez4gUmihdBrbpsEnAX/Xj16sGvZm+guceYE0NE00vLhpDVK6f3q8Q4VFI5xG8JjlXKMB/SkTTQ==",
+          "requires": {
+            "@opentelemetry/context-async-hooks": "1.25.1",
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/propagator-b3": "1.25.1",
+            "@opentelemetry/propagator-jaeger": "1.25.1",
+            "@opentelemetry/sdk-trace-base": "1.25.1",
+            "semver": "^7.5.2"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -40451,9 +43015,9 @@
       "version": "file:packages/opentelemetry-sdk-trace-base",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0",
         "@types/mocha": "10.0.7",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -40568,13 +43132,13 @@
       "version": "file:packages/opentelemetry-sdk-trace-node",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/context-async-hooks": "1.25.1",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/propagator-b3": "1.25.1",
-        "@opentelemetry/propagator-jaeger": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/context-async-hooks": "1.26.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/propagator-b3": "1.26.0",
+        "@opentelemetry/propagator-jaeger": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0",
         "@types/mocha": "10.0.7",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.8",
@@ -40626,12 +43190,12 @@
         "@babel/core": "7.24.9",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/context-zone": "1.25.1",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/propagator-b3": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/context-zone": "1.26.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/propagator-b3": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0",
         "@types/jquery": "3.5.30",
         "@types/mocha": "10.0.7",
         "@types/node": "18.6.5",
@@ -40756,16 +43320,16 @@
         "@babel/plugin-transform-runtime": "7.22.15",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/context-zone-peer-dep": "1.25.1",
-        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/context-zone-peer-dep": "1.26.0",
+        "@opentelemetry/core": "1.26.0",
         "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
-        "@opentelemetry/exporter-zipkin": "1.25.1",
+        "@opentelemetry/exporter-zipkin": "1.26.0",
         "@opentelemetry/instrumentation": "0.52.1",
         "@opentelemetry/instrumentation-fetch": "0.52.1",
         "@opentelemetry/instrumentation-xml-http-request": "0.52.1",
-        "@opentelemetry/sdk-metrics": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/sdk-trace-web": "1.25.1",
+        "@opentelemetry/sdk-metrics": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/sdk-trace-web": "1.26.0",
         "babel-loader": "8.3.0",
         "babel-polyfill": "6.26.0",
         "browserstack-local": "1.4.8",
@@ -40992,6 +43556,56 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/context-async-hooks": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.25.1.tgz",
+          "integrity": "sha512-UW/ge9zjvAEmRWVapOP0qyCvPulWU6cQxGxDbWEFfGOj1VBBZAuOqTo3X6yWmDTD3Xe15ysCZChHncr2xFMIfQ==",
+          "dev": true,
+          "requires": {}
+        },
+        "@opentelemetry/core": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+          "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-metrics": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+          "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "lodash.merge": "^4.6.2"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+          "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+          "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+        },
         "mocha": {
           "version": "10.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
@@ -41027,11 +43641,11 @@
       "version": "file:packages/opentelemetry-shim-opentracing",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/propagator-b3": "1.25.1",
-        "@opentelemetry/propagator-jaeger": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/propagator-b3": "1.26.0",
+        "@opentelemetry/propagator-jaeger": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0",
         "@types/mocha": "10.0.7",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -44090,7 +46704,7 @@
       "version": "file:experimental/backwards-compatibility/node14",
       "requires": {
         "@opentelemetry/sdk-node": "0.52.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
         "@types/node": "14.18.25",
         "typescript": "4.4.4"
       },
@@ -44107,7 +46721,7 @@
       "version": "file:experimental/backwards-compatibility/node16",
       "requires": {
         "@opentelemetry/sdk-node": "0.52.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
         "@types/node": "16.11.52",
         "typescript": "4.4.4"
       },
@@ -47092,10 +49706,10 @@
         "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
         "@opentelemetry/instrumentation": "0.52.1",
         "@opentelemetry/instrumentation-http": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/sdk-trace-node": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/sdk-trace-node": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0"
       }
     },
     "espree": {
@@ -47248,17 +49862,17 @@
       "version": "file:examples/otlp-exporter-node",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/core": "1.26.0",
         "@opentelemetry/exporter-metrics-otlp-grpc": "0.52.1",
         "@opentelemetry/exporter-metrics-otlp-http": "0.52.1",
         "@opentelemetry/exporter-metrics-otlp-proto": "0.52.1",
         "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
         "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
         "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-metrics": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-metrics": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0"
       }
     },
     "execa": {
@@ -48770,14 +51384,14 @@
       "version": "file:examples/http",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-jaeger": "1.25.1",
-        "@opentelemetry/exporter-zipkin": "1.25.1",
+        "@opentelemetry/exporter-jaeger": "1.26.0",
+        "@opentelemetry/exporter-zipkin": "1.26.0",
         "@opentelemetry/instrumentation": "0.52.1",
         "@opentelemetry/instrumentation-http": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/sdk-trace-node": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/sdk-trace-node": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0",
         "cross-env": "^6.0.0"
       }
     },
@@ -48866,14 +51480,14 @@
       "version": "file:examples/https",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/exporter-jaeger": "1.25.1",
-        "@opentelemetry/exporter-zipkin": "1.25.1",
+        "@opentelemetry/exporter-jaeger": "1.26.0",
+        "@opentelemetry/exporter-zipkin": "1.26.0",
         "@opentelemetry/instrumentation": "0.52.1",
         "@opentelemetry/instrumentation-http": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/sdk-trace-node": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/sdk-trace-node": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0",
         "cross-env": "^6.0.0"
       }
     },
@@ -53410,10 +56024,10 @@
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/exporter-prometheus": "0.52.1",
         "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-metrics": "1.25.1",
-        "@opentelemetry/sdk-trace-node": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-metrics": "1.26.0",
+        "@opentelemetry/sdk-trace-node": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0",
         "@opentelemetry/shim-opencensus": "0.52.1"
       }
     },
@@ -54316,7 +56930,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/exporter-prometheus": "0.52.1",
-        "@opentelemetry/sdk-metrics": "1.25.1"
+        "@opentelemetry/sdk-metrics": "1.26.0"
       }
     },
     "promise-all-reject-late": {
@@ -54366,9 +56980,9 @@
       "version": "file:integration-tests/propagation-validation-server",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/context-async-hooks": "1.25.1",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/context-async-hooks": "1.26.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
         "axios": "1.6.0",
         "body-parser": "1.19.0",
         "express": "4.19.2",
@@ -58084,20 +60698,20 @@
         "@babel/core": "^7.23.6",
         "@babel/preset-env": "^7.22.20",
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-zone": "1.25.1",
-        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/context-zone": "1.26.0",
+        "@opentelemetry/core": "1.26.0",
         "@opentelemetry/exporter-metrics-otlp-http": "0.52.1",
         "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
         "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
-        "@opentelemetry/exporter-zipkin": "1.25.1",
+        "@opentelemetry/exporter-zipkin": "1.26.0",
         "@opentelemetry/instrumentation": "0.52.1",
         "@opentelemetry/instrumentation-fetch": "0.52.1",
         "@opentelemetry/instrumentation-xml-http-request": "0.52.1",
-        "@opentelemetry/propagator-b3": "1.25.1",
-        "@opentelemetry/sdk-metrics": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/sdk-trace-web": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/propagator-b3": "1.26.0",
+        "@opentelemetry/sdk-metrics": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/sdk-trace-web": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.26.0",
         "babel-loader": "^8.0.6",
         "ts-loader": "^9.2.6",
         "typescript": "^4.5.2",

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-async-hooks",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "OpenTelemetry AsyncHooks-based Context Manager",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone-peer-dep",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "OpenTelemetry Context Zone with peer dependency for zone.js",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "OpenTelemetry Context Zone",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,7 +56,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.25.1",
+    "@opentelemetry/context-zone-peer-dep": "1.26.0",
     "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
   },
   "sideEffects": true,

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/core",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "OpenTelemetry Core provides constants and utilities shared by all OpenTelemetry SDK packages.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,7 +91,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "1.25.1"
+    "@opentelemetry/semantic-conventions": "1.26.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-core",
   "sideEffects": false

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-jaeger",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "OpenTelemetry Exporter Jaeger allows user to send collected traces to Jaeger",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/resources": "1.26.0",
     "@types/mocha": "10.0.7",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -63,9 +63,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.1",
-    "@opentelemetry/sdk-trace-base": "1.25.1",
-    "@opentelemetry/semantic-conventions": "1.25.1",
+    "@opentelemetry/core": "1.26.0",
+    "@opentelemetry/sdk-trace-base": "1.26.0",
+    "@opentelemetry/semantic-conventions": "1.26.0",
     "jaeger-client": "^3.15.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-jaeger",

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-zipkin",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "OpenTelemetry Zipkin Exporter allows the user to send collected traces to Zipkin.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -93,10 +93,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.1",
-    "@opentelemetry/resources": "1.25.1",
-    "@opentelemetry/sdk-trace-base": "1.25.1",
-    "@opentelemetry/semantic-conventions": "1.25.1"
+    "@opentelemetry/core": "1.26.0",
+    "@opentelemetry/resources": "1.26.0",
+    "@opentelemetry/sdk-trace-base": "1.26.0",
+    "@opentelemetry/semantic-conventions": "1.26.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-zipkin",
   "sideEffects": false

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-b3",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "OpenTelemetry B3 propagator provides context propagation for systems that are using the B3 header format",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -52,7 +52,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.1"
+    "@opentelemetry/core": "1.26.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.10.0"

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-jaeger",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "OpenTelemetry Jaeger propagator provides HTTP header propagation for systems that are using Jaeger HTTP header format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -81,7 +81,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.1"
+    "@opentelemetry/core": "1.26.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-jaeger",
   "sideEffects": false

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/resources",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "OpenTelemetry SDK resources",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -95,8 +95,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.1",
-    "@opentelemetry/semantic-conventions": "1.25.1"
+    "@opentelemetry/core": "1.26.0",
+    "@opentelemetry/semantic-conventions": "1.26.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-resources",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-base",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "OpenTelemetry Tracing",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -93,9 +93,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.1",
-    "@opentelemetry/resources": "1.25.1",
-    "@opentelemetry/semantic-conventions": "1.25.1"
+    "@opentelemetry/core": "1.26.0",
+    "@opentelemetry/resources": "1.26.0",
+    "@opentelemetry/semantic-conventions": "1.26.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-base",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-node",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "OpenTelemetry Node SDK provides automatic telemetry (tracing, metrics, etc) for Node.js applications",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -47,8 +47,8 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.10.0",
-    "@opentelemetry/resources": "1.25.1",
-    "@opentelemetry/semantic-conventions": "1.25.1",
+    "@opentelemetry/resources": "1.26.0",
+    "@opentelemetry/semantic-conventions": "1.26.0",
     "@types/mocha": "10.0.7",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.8",
@@ -65,11 +65,11 @@
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/context-async-hooks": "1.25.1",
-    "@opentelemetry/core": "1.25.1",
-    "@opentelemetry/propagator-b3": "1.25.1",
-    "@opentelemetry/propagator-jaeger": "1.25.1",
-    "@opentelemetry/sdk-trace-base": "1.25.1",
+    "@opentelemetry/context-async-hooks": "1.26.0",
+    "@opentelemetry/core": "1.26.0",
+    "@opentelemetry/propagator-b3": "1.26.0",
+    "@opentelemetry/propagator-jaeger": "1.26.0",
+    "@opentelemetry/sdk-trace-base": "1.26.0",
     "semver": "^7.5.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node",

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-web",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "OpenTelemetry Web Tracer",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -59,9 +59,9 @@
     "@babel/core": "7.24.9",
     "@babel/preset-env": "7.24.7",
     "@opentelemetry/api": ">=1.0.0 <1.10.0",
-    "@opentelemetry/context-zone": "1.25.1",
-    "@opentelemetry/propagator-b3": "1.25.1",
-    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/context-zone": "1.26.0",
+    "@opentelemetry/propagator-b3": "1.26.0",
+    "@opentelemetry/resources": "1.26.0",
     "@types/jquery": "3.5.30",
     "@types/mocha": "10.0.7",
     "@types/node": "18.6.5",
@@ -93,9 +93,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.1",
-    "@opentelemetry/sdk-trace-base": "1.25.1",
-    "@opentelemetry/semantic-conventions": "1.25.1"
+    "@opentelemetry/core": "1.26.0",
+    "@opentelemetry/sdk-trace-base": "1.26.0",
+    "@opentelemetry/semantic-conventions": "1.26.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-web",
   "sideEffects": false

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opentracing",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "OpenTracing to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,9 +44,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.10.0",
-    "@opentelemetry/propagator-b3": "1.25.1",
-    "@opentelemetry/propagator-jaeger": "1.25.1",
-    "@opentelemetry/sdk-trace-base": "1.25.1",
+    "@opentelemetry/propagator-b3": "1.26.0",
+    "@opentelemetry/propagator-jaeger": "1.26.0",
+    "@opentelemetry/sdk-trace-base": "1.26.0",
     "@types/mocha": "10.0.7",
     "@types/node": "18.6.5",
     "codecov": "3.8.3",
@@ -60,8 +60,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.1",
-    "@opentelemetry/semantic-conventions": "1.25.1",
+    "@opentelemetry/core": "1.26.0",
+    "@opentelemetry/semantic-conventions": "1.26.0",
     "opentracing": "^0.14.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-shim-opentracing",

--- a/packages/propagator-aws-xray/package.json
+++ b/packages/propagator-aws-xray/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-aws-xray",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "OpenTelemetry AWS Xray propagator provides context propagation for systems that are using AWS X-Ray format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -79,7 +79,7 @@
     "webpack": "5.89.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.1"
+    "@opentelemetry/core": "1.26.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/propagator-aws-xray#readme"
 }

--- a/packages/sdk-metrics/package.json
+++ b/packages/sdk-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-metrics",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "OpenTelemetry metrics SDK",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -85,8 +85,8 @@
     "@opentelemetry/api": ">=1.3.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.1",
-    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/core": "1.26.0",
+    "@opentelemetry/resources": "1.26.0",
     "lodash.merge": "^4.6.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/sdk-metrics",

--- a/packages/semantic-conventions/package.json
+++ b/packages/semantic-conventions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/semantic-conventions",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "OpenTelemetry semantic conventions",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/template",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/selenium-tests/package.json
+++ b/selenium-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/selenium-tests",
-  "version": "1.26.1",
+  "version": "1.27.0",
   "private": true,
   "description": "OpenTelemetry Selenium Tests",
   "main": "index.js",
@@ -57,16 +57,16 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.25.1",
-    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/context-zone-peer-dep": "1.26.0",
+    "@opentelemetry/core": "1.26.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
-    "@opentelemetry/exporter-zipkin": "1.25.1",
+    "@opentelemetry/exporter-zipkin": "1.26.0",
     "@opentelemetry/instrumentation": "0.52.1",
     "@opentelemetry/instrumentation-fetch": "0.52.1",
     "@opentelemetry/instrumentation-xml-http-request": "0.52.1",
-    "@opentelemetry/sdk-metrics": "1.25.1",
-    "@opentelemetry/sdk-trace-base": "1.25.1",
-    "@opentelemetry/sdk-trace-web": "1.25.1",
+    "@opentelemetry/sdk-metrics": "1.26.0",
+    "@opentelemetry/sdk-trace-base": "1.26.0",
+    "@opentelemetry/sdk-trace-web": "1.26.0",
     "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
   }
 }


### PR DESCRIPTION
## 1.26.0

### :rocket: (Enhancement)

* feat: include instrumentation scope info in console span and log record exporters [#4848](https://github.com/open-telemetry/opentelemetry-js/pull/4848) @blumamir
* feat(semconv): update semantic conventions to 1.27 (from 1.7.0) [#4690](https://github.com/open-telemetry/opentelemetry-js/pull/4690) @dyladan
  * Exported names have changed to `ATTR_{name}` for attributes (e.g. `ATTR_HTTP_REQUEST_METHOD`), `{name}_VALUE_{value}` for enumeration values (e.g. `HTTP_REQUEST_METHOD_VALUE_POST`), and `METRIC_{name}` for metrics. Exported names from previous versions are deprecated.
  * Import `@opentelemetry/semantic-conventions` for *stable* semantic conventions. Import `@opentelemetry/semantic-conventions/incubating` for all semantic conventions, stable and unstable.
  * Note: Semantic conventions are now versioned separately from other stable artifacts, to correspond to the version of semantic conventions they provide.

### :bug: (Bug Fix)

* fix(sdk-node): avoid spurious diag errors for unknown OTEL_NODE_RESOURCE_DETECTORS values [#4879](https://github.com/open-telemetry/opentelemetry-js/pull/4879) @trentm
* deps(opentelemetry-instrumentation): Bump `shimmer` types to 1.2.0 [#4865](https://github.com/open-telemetry/opentelemetry-js/pull/4865) @lforst

### :house: (Internal)

* refactor: Simplify the code for the `getEnv` function [#4799](https://github.com/open-telemetry/opentelemetry-js/pull/4799) @danstarns


## 0.52.1

### :rocket: (Enhancement)

* refactor(instrumentation-fetch): move fetch to use SEMATRR [#4632](https://github.com/open-telemetry/opentelemetry-js/pull/4632)
* refactor(otlp-transformer): use explicit exports [#4785](https://github.com/open-telemetry/opentelemetry-js/pull/4785) @pichlermarc

### :bug: (Bug Fix)

* fix(sdk-node): register context manager if no tracer options are provided [#4781](https://github.com/open-telemetry/opentelemetry-js/pull/4781) @pichlermarc
* fix(instrumentation): Update `import-in-the-middle` to fix [numerous bugs](https://github.com/DataDog/import-in-the-middle/releases/tag/v1.8.1) [#4806](https://github.com/open-telemetry/opentelemetry-js/pull/4806) @timfish
* chore(instrumentation): Use a caret version for `import-in-the-middle` dependency [#4810](https://github.com/open-telemetry/opentelemetry-js/pull/4810) @timfish

### :house: (Internal)

* test: add `npm run maint:regenerate-test-certs` maintenance script and regenerate recently expired test certs [#4777](https://github.com/open-telemetry/opentelemetry-js/pull/4777)

